### PR TITLE
Fix filetree bugs

### DIFF
--- a/filetree.cpp
+++ b/filetree.cpp
@@ -41,7 +41,7 @@ bool FileTree::find_node(const std::string &path, TreeNode **last_node)const{
         *last_node = node;
         node = node->firstSon;
     }
-    return true && node->isFile;
+    return (*last_node)->isFile;
 }
 
 void FileTree::list(TreeNode *node, std::map<std::string, std::pair<int, int>>& meta){

--- a/filetree.cpp
+++ b/filetree.cpp
@@ -14,18 +14,56 @@ bool FileTree::insert_node(const std::string &path, const bool isFile){
     if(isFound) return false;
 
     std::vector<std::string> path_folders = split(path, '/');
-    TreeNode *newNode = new TreeNode(path, isFile);
-    newNode->parent = parent;
-    TreeNode* son = parent->firstSon;
-    if(!son)
-        parent->firstSon = newNode;
-    else{
-        while(son->nextSibling)
-            son = son->nextSibling;
-        son->nextSibling = newNode;
+    TreeNode* match = _root;
+    TreeNode* cur = _root->firstSon;
+    for (size_t i = 0; i < path_folders.size(); ++i) {
+      // Try to get the node
+      while (cur && cur->value_ != path_folders[i]) {
+        cur = cur->nextSibling;
+      }
+
+      // Found the node, try next layer
+      if (cur) {
+        match = cur;
+        cur = cur->firstSon;
+        continue;
+      }
+
+      // If the last layer, add node directly
+      if (i + 1 == path_folders.size()) {
+        // create this node of file
+        auto node = new TreeNode(path_folders[i], true);
+        node->parent = match;
+        if (!match->firstSon) {
+          match->firstSon = node;
+        } else {
+          auto sibling = match->firstSon;
+          while (sibling->nextSibling) {
+            sibling = sibling->nextSibling;
+          }
+          sibling->nextSibling = node;
+        }
+
+        return true;
+      }
+
+      // If not the last layer, add missing dir node
+      auto dir = new TreeNode(path_folders[i], false);
+      dir->parent = match;
+      if (!match->firstSon) {
+        match->firstSon = dir;
+      } else {
+        auto sibling = match->firstSon;
+        while (sibling->nextSibling) {
+          sibling = sibling->nextSibling;
+        }
+        sibling->nextSibling = dir;
+      }
+
+      match = dir;
+      cur = match->firstSon;
     }
-    while(son) son = son->nextSibling;
-    son = newNode;
+
     return true;
 }
 

--- a/filetree.cpp
+++ b/filetree.cpp
@@ -85,7 +85,10 @@ bool FileTree::find_node(const std::string &path, TreeNode **last_node)const{
 void FileTree::list(TreeNode *node, std::map<std::string, std::pair<int, int>>& meta){
     static int chunkSize = 2 * 1024 * 1024;
     if(node){
-        std::cout << node->value_ << "\t" << meta[node->value_].first << "\t" << (int)ceil(1.0 * meta[node->value_].second/chunkSize) << std::endl;
+        if (node->isFile) {
+          auto full_path_of_file = list_node_path(node);
+          std::cout << full_path_of_file << "\t" << meta[full_path_of_file].first << "\t" << (int)ceil(1.0 * meta[full_path_of_file].second/chunkSize) << std::endl;
+        }
         // std::cout << node->value_ << "\t" << std::endl;
         list(node->firstSon, meta);
         list(node->nextSibling, meta);
@@ -94,4 +97,13 @@ void FileTree::list(TreeNode *node, std::map<std::string, std::pair<int, int>>& 
 
 void FileTree::list(std::map<std::string, std::pair<int, int>>& meta){
     list(_root, meta);
+}
+
+const std::string FileTree::list_node_path(TreeNode* node) {
+  while (node->parent) {
+    return list_node_path(node->parent) + "/" + node->value_;
+  }
+
+  // Don't return the root value, which is '/'
+  return (node->value_ != "/") ? node->value_ : "";
 }

--- a/filetree.h
+++ b/filetree.h
@@ -23,6 +23,7 @@ public:
     bool find_node(const std::string &path, TreeNode **parent)const;
     void list(TreeNode *node, std::map<std::string, std::pair<int, int>>& meta);
     void list(std::map<std::string, std::pair<int, int>>& meta);
+    const std::string list_node_path(TreeNode* node);
 };
 
 #endif

--- a/nameserver.cpp
+++ b/nameserver.cpp
@@ -63,7 +63,7 @@ void NameServer::operator()(){
                 continue;
             }
             else if (!fileTree_.insert_node(parameters[2], true)){
-                std::cerr << "create file error \n.maybe the file : " << parameters[2] << "exists" << std::endl;
+                std::cerr << "create file error \n.maybe the file : " << parameters[2] << " exists" << std::endl;
                 continue;
             }
             else{


### PR DESCRIPTION
This PR solves those bugs.  
1. Segmentfault when put file to identical paths  
2. Put file to identical paths can be successful multiple times.
3. command list & ls gives inaccurate information.

Notice: Only print file path in list & ls command now, not directory.